### PR TITLE
feat: AuthRequired widget を実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_firebase_sample/models/app_theme_model.dart';
 import 'package:flutter_firebase_sample/models/auth_model.dart';
 import 'package:flutter_firebase_sample/pages/home_page.dart';
-import 'package:flutter_firebase_sample/pages/login_page.dart';
+import 'package:flutter_firebase_sample/pages/introduction_page.dart';
 import 'package:provider/provider.dart';
 
 void main() {
@@ -77,7 +77,7 @@ class MyAppWidget extends StatelessWidget {
       ),
       routes: {
         '/': (context) => const HomePage(),
-        '/login': (context) => const LoginPage(),
+        '/introduction': (context) => const IntroductionPage(),
       },
       initialRoute: '/',
     );

--- a/lib/models/auth_model.dart
+++ b/lib/models/auth_model.dart
@@ -1,8 +1,11 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
+enum AuthStatus { initial, signIn, signOut }
+
 class AuthModel extends ChangeNotifier {
   User? firebaseUser;
+  AuthStatus authStatus = AuthStatus.initial;
 
   AuthModel() {
     init();
@@ -10,7 +13,13 @@ class AuthModel extends ChangeNotifier {
 
   void init() {
     FirebaseAuth.instance.authStateChanges().listen((user) {
-      firebaseUser = user;
+      if (user == null) {
+        firebaseUser = null;
+        authStatus = AuthStatus.signOut;
+      } else {
+        firebaseUser = user;
+        authStatus = AuthStatus.signIn;
+      }
       notifyListeners();
     });
   }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -39,9 +39,9 @@ class HomePage extends StatelessWidget {
             ),
             const Text('画面遷移'),
             ElevatedButton(
-              child: const Text('Login'),
+              child: const Text('Introduction'),
               onPressed: () {
-                Navigator.of(context).pushNamed('/login');
+                Navigator.of(context).pushNamed('/introduction');
               },
             ),
           ],

--- a/lib/pages/introduction_page.dart
+++ b/lib/pages/introduction_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_firebase_sample/widgets/auth_required.dart';
+
+class IntroductionPage extends StatelessWidget {
+  const IntroductionPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(context) {
+    return AuthRequired(
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Introduction'),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              Text('説明'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/auth_required.dart
+++ b/lib/widgets/auth_required.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_firebase_sample/models/auth_model.dart';
+import 'package:flutter_firebase_sample/pages/login_page.dart';
+import 'package:provider/provider.dart';
+
+class AuthRequired extends StatelessWidget {
+  final Widget child;
+
+  const AuthRequired({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(context) {
+    final authStatus = context.select<AuthModel?, AuthStatus>(
+        (auth) => auth?.authStatus ?? AuthStatus.initial);
+
+    if (authStatus == AuthStatus.signIn) {
+      return child;
+    }
+
+    if (authStatus == AuthStatus.signOut) {
+      return const LoginPage();
+    }
+
+    return _AuthLoading();
+  }
+}
+
+class _AuthLoading extends StatelessWidget {
+  @override
+  Widget build(context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('処理中'),
+      ),
+      body: const Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概要

未ログイン時はログイン画面を表示する `AuthRequired` widget を実装

`AuthModel` に `authStatus` を追加
`authStateChanges()` が未解決のときは `initial` を取り、解決済みの場合はログイン状態に応じて `signIn`, `signOut` になる
