### PR TITLE
feat: ログイン機能を実装

### DIFF
--- a/lib/models/auth_model.dart
+++ b/lib/models/auth_model.dart
@@ -23,4 +23,22 @@ class AuthModel extends ChangeNotifier {
       notifyListeners();
     });
   }
+
+  Future<FirebaseAuthException?> signInWithEmailAndPassword({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+    } on FirebaseAuthException catch (e) {
+      return e;
+    }
+  }
+
+  Future<void> signOut() async {
+    await FirebaseAuth.instance.signOut();
+  }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_firebase_sample/models/app_theme_model.dart';
+import 'package:flutter_firebase_sample/pages/login_page.dart';
+import 'package:flutter_firebase_sample/widgets/switch_auth_widget.dart';
 import 'package:provider/provider.dart';
 
 class HomePage extends StatelessWidget {
@@ -38,15 +40,45 @@ class HomePage extends StatelessWidget {
               ],
             ),
             const Text('画面遷移'),
+            _PrivateLinkButton(),
             ElevatedButton(
-              child: const Text('Introduction'),
+              child: const Text('ログインチェックなし遷移'),
               onPressed: () {
                 Navigator.of(context).pushNamed('/introduction');
               },
-            ),
+            )
           ],
         ),
       ),
     );
+  }
+}
+
+class _PrivateLinkButton extends StatelessWidget {
+  @override
+  Widget build(context) {
+    return SwitchAuthWidget(
+      child: ElevatedButton(
+        child: _buttonText(),
+        onPressed: () {
+          Navigator.of(context).pushNamed('/introduction');
+        },
+      ),
+      fallbackChild: ElevatedButton(
+        child: _buttonText(),
+        onPressed: () {
+          Navigator.of(context).push(MaterialPageRoute(
+            builder: (context) {
+              return const LoginPage();
+            },
+            fullscreenDialog: true,
+          ));
+        },
+      ),
+    );
+  }
+
+  Widget _buttonText() {
+    return const Text('ログインチェックあり遷移');
   }
 }

--- a/lib/pages/introduction_page.dart
+++ b/lib/pages/introduction_page.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_firebase_sample/models/auth_model.dart';
 import 'package:flutter_firebase_sample/widgets/auth_required.dart';
+import 'package:provider/provider.dart';
 
 class IntroductionPage extends StatelessWidget {
   const IntroductionPage({Key? key}) : super(key: key);
 
   @override
   Widget build(context) {
+    final signOut = context
+        .select<AuthModel?, Future<void> Function()?>((auth) => auth?.signOut);
+
     return AuthRequired(
       child: Scaffold(
         appBar: AppBar(
@@ -14,8 +19,18 @@ class IntroductionPage extends StatelessWidget {
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
-            children: const [
-              Text('説明'),
+            children: [
+              const Text('説明'),
+              ElevatedButton(
+                child: const Text('ログアウト'),
+                onPressed: () async {
+                  if (signOut != null) {
+                    await signOut();
+                    Navigator.of(context)
+                        .pushNamedAndRemoveUntil("/", (route) => false);
+                  }
+                },
+              )
             ],
           ),
         ),

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_firebase_sample/widgets/signin_form.dart';
 
 class LoginPage extends StatelessWidget {
   const LoginPage({Key? key}) : super(key: key);
@@ -9,17 +10,15 @@ class LoginPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Login'),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              child: const Text('Back'),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            )
-          ],
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              SignInForm(),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/signin_form.dart
+++ b/lib/widgets/signin_form.dart
@@ -1,0 +1,75 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_firebase_sample/models/auth_model.dart';
+import 'package:provider/provider.dart';
+
+class SignInForm extends StatefulWidget {
+  const SignInForm({Key? key}) : super(key: key);
+
+  @override
+  _SignInFormState createState() => _SignInFormState();
+}
+
+class _SignInFormState extends State<SignInForm> {
+  final _formKey = GlobalKey<FormState>();
+  String email = '';
+  String password = '';
+
+  @override
+  Widget build(context) {
+    final signIn = context.select<
+        AuthModel?,
+        Future<FirebaseAuthException?> Function({
+      required String email,
+      required String password,
+    })?>((auth) => auth?.signInWithEmailAndPassword);
+
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'メールアドレス'),
+            keyboardType: TextInputType.emailAddress,
+            onChanged: (value) {
+              setState(() {
+                email = value;
+              });
+            },
+          ),
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'パスワード'),
+            keyboardType: TextInputType.visiblePassword,
+            obscureText: true,
+            onChanged: (value) {
+              setState(() {
+                password = value;
+              });
+            },
+          ),
+          ElevatedButton(
+            child: const Text('ログイン'),
+            onPressed: () async {
+              if (signIn == null) {
+                return;
+              }
+
+              final error = await signIn(email: email, password: password);
+              if (error != null) {
+                return;
+              }
+
+              final navigator = Navigator.of(context);
+              if (navigator.canPop()) {
+                navigator.maybePop();
+              } else {
+                navigator.pushNamedAndRemoveUntil('/', (route) => false);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/switch_auth_widget.dart
+++ b/lib/widgets/switch_auth_widget.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_firebase_sample/models/auth_model.dart';
+import 'package:provider/provider.dart';
+
+class SwitchAuthWidget extends StatelessWidget {
+  final Widget child;
+  final Widget fallbackChild;
+
+  const SwitchAuthWidget({
+    Key? key,
+    required this.child,
+    required this.fallbackChild,
+  }) : super(key: key);
+
+  @override
+  Widget build(context) {
+    final authStatus = context.select<AuthModel?, AuthStatus>(
+        (auth) => auth?.authStatus ?? AuthStatus.initial);
+
+    if (authStatus == AuthStatus.signIn) {
+      return child;
+    }
+
+    return fallbackChild;
+  }
+}


### PR DESCRIPTION
メールアドレス、パスワードでのログイン機能を実装
新規登録は無いため Firebase コンソールでアカウントを追加しておく必要がある

`SwitchAuthWidget` はログイン状態に応じて Widget の出し分けを行う Widget
これを使って未ログイン時にログイン画面を表示し、ログイン時は画面遷移する処理を実現している。

前回作った `AuthRequired` はいまいちだった。
要ログイン画面を作るときに囲うことで、未ログイン時はログイン画面を表示し、ログイン後は本来の画面を表示する目的で作成したが、
ログイン完了後に、ぱっと画面が切り替わってしまうので、アプリらしい遷移にならなかった。